### PR TITLE
Change Gradle dependency example to use correct declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ In your Maven project, add this dependency:
 
 ```groovy
 dependencies {
-    implementation 'com.github.ollama4j:ollama4j:1.0.79'
+    implementation 'io.github.ollama4j:ollama4j:1.0.79'
 }
 ```
 


### PR DESCRIPTION
Currently, the Gradle dependency example in the README inaccurately reads as `com.github.ollama4j:ollama4j:1.0.82` when it should be `io.github.ollama4j:ollama4j:1.0.82` per the Maven examples and https://central.sonatype.com/artifact/io.github.ollama4j/ollama4j/overview