### PR TITLE
Add minp option and ability to set custom options

### DIFF
--- a/src/main/java/io/github/ollama4j/utils/OptionsBuilder.java
+++ b/src/main/java/io/github/ollama4j/utils/OptionsBuilder.java
@@ -1,5 +1,6 @@
 package io.github.ollama4j.utils;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 /** Builder class for creating options for Ollama model. */
@@ -223,6 +224,7 @@ public class OptionsBuilder {
    * @param name The option name for the parameter.
    * @param value The value for the "{name}" parameter.
    * @return The updated OptionsBuilder.
+   * @throws IllegalArgumentException if parameter has an unsupported type
    */
   public OptionsBuilder setCustomOption(String name, Object value) throws IllegalArgumentException {
     if (!(value instanceof Integer || value instanceof Float || value instanceof String)) {

--- a/src/main/java/io/github/ollama4j/utils/OptionsBuilder.java
+++ b/src/main/java/io/github/ollama4j/utils/OptionsBuilder.java
@@ -208,6 +208,33 @@ public class OptionsBuilder {
   }
 
   /**
+   * Alternative to the top_p, and aims to ensure a balance of qualityand variety. The parameter p
+   * represents the minimum probability for a token to be considered, relative to the probability
+   * of the most likely token. For example, with p=0.05 and the most likely token having a
+   * probability of 0.9, logits with a value less than 0.045 are filtered out. (Default: 0.0)
+   */
+  public OptionsBuilder setMinP(float value) {
+    options.getOptionsMap().put("min_p", value);
+    return this;
+  }
+
+  /**
+   * Allows passing an option not formally supported by the library
+   * @param name The option name for the parameter.
+   * @param value The value for the "{name}" parameter.
+   * @return The updated OptionsBuilder.
+   */
+  public OptionsBuilder setCustomOption(String name, Object value) throws IllegalArgumentException {
+    if (!(value instanceof Integer || value instanceof Float || value instanceof String)) {
+      throw new IllegalArgumentException("Invalid type for parameter. Allowed types are: Integer, Float, or String.");
+    }
+    options.getOptionsMap().put(name, value);
+    return this;
+  }
+
+
+
+  /**
    * Builds the options map.
    *
    * @return The populated options map.
@@ -215,4 +242,6 @@ public class OptionsBuilder {
   public Options build() {
     return options;
   }
+
+
 }

--- a/src/test/java/io/github/ollama4j/unittests/jackson/TestChatRequestSerialization.java
+++ b/src/test/java/io/github/ollama4j/unittests/jackson/TestChatRequestSerialization.java
@@ -3,10 +3,12 @@ package io.github.ollama4j.unittests.jackson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
+import java.security.InvalidParameterException;
 import java.util.List;
 
 import io.github.ollama4j.models.chat.OllamaChatRequest;
 import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +61,10 @@ public class TestChatRequestSerialization extends AbstractSerializationTest<Olla
             .withOptions(b.setSeed(1).build())
             .withOptions(b.setTopK(1).build())
             .withOptions(b.setTopP(1).build())
+            .withOptions(b.setMinP(1).build())
+            .withOptions(b.setCustomOption("cust_float", 1.0f).build())
+            .withOptions(b.setCustomOption("cust_int", 1).build())
+            .withOptions(b.setCustomOption("cust_str", "custom").build())
             .build();
 
         String jsonRequest = serialize(req);
@@ -72,6 +78,20 @@ public class TestChatRequestSerialization extends AbstractSerializationTest<Olla
         assertEquals(1, deserializeRequest.getOptions().get("seed"));
         assertEquals(1, deserializeRequest.getOptions().get("top_k"));
         assertEquals(1.0, deserializeRequest.getOptions().get("top_p"));
+        assertEquals(1.0, deserializeRequest.getOptions().get("min_p"));
+        assertEquals(1.0, deserializeRequest.getOptions().get("cust_float"));
+        assertEquals(1, deserializeRequest.getOptions().get("cust_int"));
+        assertEquals("custom", deserializeRequest.getOptions().get("cust_str"));
+    }
+
+    @Test
+    public void testRequestWithInvalidCustomOption() {
+        OptionsBuilder b = new OptionsBuilder();
+        Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> {
+                OllamaChatRequest req = builder.withMessage(OllamaChatMessageRole.USER, "Some prompt")
+                .withOptions(b.setCustomOption("cust_obj", new Object()).build())
+                .build();
+        });
     }
 
     @Test

--- a/src/test/java/io/github/ollama4j/unittests/jackson/TestChatRequestSerialization.java
+++ b/src/test/java/io/github/ollama4j/unittests/jackson/TestChatRequestSerialization.java
@@ -1,14 +1,13 @@
 package io.github.ollama4j.unittests.jackson;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import java.io.File;
-import java.security.InvalidParameterException;
 import java.util.List;
 
 import io.github.ollama4j.models.chat.OllamaChatRequest;
 import org.json.JSONObject;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -87,7 +86,7 @@ public class TestChatRequestSerialization extends AbstractSerializationTest<Olla
     @Test
     public void testRequestWithInvalidCustomOption() {
         OptionsBuilder b = new OptionsBuilder();
-        Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> {
+        assertThrowsExactly(IllegalArgumentException.class, () -> {
                 OllamaChatRequest req = builder.withMessage(OllamaChatMessageRole.USER, "Some prompt")
                 .withOptions(b.setCustomOption("cust_obj", new Object()).build())
                 .build();


### PR DESCRIPTION
I found myself wanting to use one of the options that wasn't already added to the library - `min_p`.

This pull request adds `min_p`

It also adds the ability to specify a custom option, useful in cases where the library hasn't yet been contributed to when a new parameter has been released.

The custom parameter addition currently checks to make sure the value is one of the three types
already used by the options builder.

If you would like any changes to this pull request, or have other feedback, please let me know, thanks!