### PR TITLE
Add 'tool' role

### DIFF
--- a/src/main/java/io/github/ollama4j/models/chat/OllamaChatMessageRole.java
+++ b/src/main/java/io/github/ollama4j/models/chat/OllamaChatMessageRole.java
@@ -8,7 +8,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum OllamaChatMessageRole {
     SYSTEM("system"),
     USER("user"),
-    ASSISTANT("assistant");
+    ASSISTANT("assistant"),
+    TOOL("tool");
 
     @JsonValue
     private String roleName;


### PR DESCRIPTION
Adds tool role, since it seems that OpenAI and Ollama itself are standardizing around that role name for use with tool calling.
https://ollama.com/library/llama3.1/blobs/948af2743fc7#:~:text=if%20eq%20.Role-,%22tool%22,-%7D%7D%3C%7Cstart_header_id%7C%3Eipython%3C%7Cend_header_id

Relates to #71 

I'm not too sure on if many other models use function or other names so I've only included tool for now since I've seen it in a few places. Role could probably become a String field in the API (and have the known roles provided as static Strings like mentioned in #71) eventually but I didn't feel like breaking the current library definitions to do that 😆 