### PR TITLE
Feature/annotation based tools

### DIFF
--- a/src/main/java/io/github/ollama4j/OllamaAPI.java
+++ b/src/main/java/io/github/ollama4j/OllamaAPI.java
@@ -15,11 +15,17 @@ import io.github.ollama4j.models.ps.ModelsProcessResponse;
 import io.github.ollama4j.models.request.*;
 import io.github.ollama4j.models.response.*;
 import io.github.ollama4j.tools.*;
+import io.github.ollama4j.tools.annotations.OllamaToolService;
+import io.github.ollama4j.tools.annotations.ToolProperty;
+import io.github.ollama4j.tools.annotations.ToolSpec;
 import io.github.ollama4j.utils.Options;
 import io.github.ollama4j.utils.Utils;
 import lombok.Setter;
 
 import java.io.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -603,6 +609,15 @@ public class OllamaAPI {
         OllamaToolsResult toolResult = new OllamaToolsResult();
         Map<ToolFunctionCallSpec, Object> toolResults = new HashMap<>();
 
+        if(!prompt.startsWith("[AVAILABLE_TOOLS]")){
+            final Tools.PromptBuilder promptBuilder = new Tools.PromptBuilder();
+            for(Tools.ToolSpecification spec :  toolRegistry.getRegisteredSpecs()) {
+                promptBuilder.withToolSpecification(spec);
+            }
+            promptBuilder.withPrompt(prompt);
+            prompt = promptBuilder.build();
+        }
+
         OllamaResult result = generate(model, prompt, raw, options, null);
         toolResult.setModelResult(result);
 
@@ -809,6 +824,94 @@ public class OllamaAPI {
 
     public void registerTool(Tools.ToolSpecification toolSpecification) {
         toolRegistry.addTool(toolSpecification.getFunctionName(), toolSpecification);
+    }
+
+    public void registerAnnotatedTools()  {
+        Class<?> callerClass = null;
+        try {
+            callerClass = Class.forName(Thread.currentThread().getStackTrace()[2].getClassName());
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
+        OllamaToolService ollamaToolServiceAnnotation = callerClass.getDeclaredAnnotation(OllamaToolService.class);
+        if(ollamaToolServiceAnnotation == null) {
+            throw new IllegalStateException(callerClass + " is not annotated as " + OllamaToolService.class);
+        }
+
+        Class<?>[] providers = ollamaToolServiceAnnotation.providers();
+
+        for(Class<?> provider : providers){
+            System.err.println("Provider: " + provider.getName());
+            Method[] methods = provider.getMethods();
+            for(Method m : methods) {
+                ToolSpec toolSpec = m.getDeclaredAnnotation(ToolSpec.class);
+                if(toolSpec == null){
+                    continue;
+                }
+                String operationName = !toolSpec.name().isBlank() ? toolSpec.name() : m.getName();
+                String operationDesc = !toolSpec.desc().isBlank() ? toolSpec.desc() : operationName;
+                System.err.println("Method: " + operationName);
+
+                final Tools.PropsBuilder propsBuilder = new Tools.PropsBuilder();
+                LinkedHashMap<String,String> methodParams = new LinkedHashMap<>();
+                for (Parameter parameter : m.getParameters()) {
+                    final ToolProperty toolPropertyAnn = parameter.getDeclaredAnnotation(ToolProperty.class);
+                    String propType = parameter.getType().getTypeName();
+                    if(toolPropertyAnn == null) {
+                        methodParams.put(parameter.getName(),null);
+                        continue;
+                    }
+                    String propName = !toolPropertyAnn.name().isBlank() ? toolPropertyAnn.name() : parameter.getName();
+                    methodParams.put(propName,propType);
+                    propsBuilder.withProperty(propName,Tools.PromptFuncDefinition.Property.builder()
+                            .type(propType)
+                            .description(toolPropertyAnn.desc())
+                            .required(toolPropertyAnn.required())
+                            .build());
+                }
+                final Map<String, Tools.PromptFuncDefinition.Property> params = propsBuilder.build();
+                List<String> reqProps = params.entrySet().stream()
+                        .filter(e -> e.getValue().isRequired())
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toList());
+
+                Tools.ToolSpecification toolSpecification = Tools.ToolSpecification.builder()
+                        .functionName(operationName)
+                        .functionDescription(operationDesc)
+                        .toolPrompt(
+                                Tools.PromptFuncDefinition.builder().type("function").function(
+                                        Tools.PromptFuncDefinition.PromptFuncSpec.builder()
+                                                .name(operationName)
+                                                .description(operationDesc)
+                                                .parameters(
+                                                        Tools.PromptFuncDefinition.Parameters.builder()
+                                                                .type("object")
+                                                                .properties(
+                                                                        params
+                                                                )
+                                                                .required(reqProps)
+                                                                .build()
+                                                ).build()
+                                ).build()
+                        )
+                        .build();
+
+                try {
+                    ReflectionalToolFunction reflectionalToolFunction =
+                            new ReflectionalToolFunction(provider.getDeclaredConstructor().newInstance()
+                                    ,m
+                                    ,methodParams);
+
+                    toolSpecification.setToolFunction(reflectionalToolFunction);
+                    toolRegistry.addTool(toolSpecification.getFunctionName(),toolSpecification);
+                } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                         NoSuchMethodException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
     }
 
     /**

--- a/src/main/java/io/github/ollama4j/OllamaAPI.java
+++ b/src/main/java/io/github/ollama4j/OllamaAPI.java
@@ -842,7 +842,6 @@ public class OllamaAPI {
         Class<?>[] providers = ollamaToolServiceAnnotation.providers();
 
         for(Class<?> provider : providers){
-            System.err.println("Provider: " + provider.getName());
             Method[] methods = provider.getMethods();
             for(Method m : methods) {
                 ToolSpec toolSpec = m.getDeclaredAnnotation(ToolSpec.class);
@@ -851,7 +850,6 @@ public class OllamaAPI {
                 }
                 String operationName = !toolSpec.name().isBlank() ? toolSpec.name() : m.getName();
                 String operationDesc = !toolSpec.desc().isBlank() ? toolSpec.desc() : operationName;
-                System.err.println("Method: " + operationName);
 
                 final Tools.PropsBuilder propsBuilder = new Tools.PropsBuilder();
                 LinkedHashMap<String,String> methodParams = new LinkedHashMap<>();

--- a/src/main/java/io/github/ollama4j/tools/ReflectionalToolFunction.java
+++ b/src/main/java/io/github/ollama4j/tools/ReflectionalToolFunction.java
@@ -1,0 +1,49 @@
+package io.github.ollama4j.tools;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class ReflectionalToolFunction implements ToolFunction{
+
+    private Object functionHolder;
+    private Method function;
+    private LinkedHashMap<String,String> propertyDefinition;
+
+    @Override
+    public Object apply(Map<String, Object> arguments) {
+        LinkedHashMap<String, Object> argumentsCopy = new LinkedHashMap<>(this.propertyDefinition);
+        for (Map.Entry<String,String> param : this.propertyDefinition.entrySet()){
+            argumentsCopy.replace(param.getKey(),typeCast(arguments.get(param.getKey()),param.getValue()));
+        }
+        try {
+            return function.invoke(functionHolder, argumentsCopy.values().toArray());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to invoke tool: " + function.getName(), e);
+        }
+    }
+
+    private Object typeCast(Object inputValue, String className) {
+        if(className == null || inputValue == null) {
+            return null;
+        }
+        String inputValueString = inputValue.toString();
+        if("java.lang.Integer".equals(className)){
+            return Integer.parseInt(inputValueString);
+        }
+        if("java.lang.Boolean".equals(className)){
+            return Boolean.valueOf(inputValueString);
+        }
+        else {
+            return inputValueString;
+        }
+    }
+
+}

--- a/src/main/java/io/github/ollama4j/tools/ReflectionalToolFunction.java
+++ b/src/main/java/io/github/ollama4j/tools/ReflectionalToolFunction.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -38,14 +39,15 @@ public class ReflectionalToolFunction implements ToolFunction{
             return null;
         }
         String inputValueString = inputValue.toString();
-        if("java.lang.Integer".equals(className)){
-            return Integer.parseInt(inputValueString);
-        }
-        if("java.lang.Boolean".equals(className)){
-            return Boolean.valueOf(inputValueString);
-        }
-        else {
-            return inputValueString;
+        switch (className) {
+            case "java.lang.Integer":
+                return Integer.parseInt(inputValueString);
+            case "java.lang.Boolean":
+                return Boolean.valueOf(inputValueString);
+            case "java.math.BigDecimal":
+                return new BigDecimal(inputValueString);
+            default:
+                return inputValueString;
         }
     }
 

--- a/src/main/java/io/github/ollama4j/tools/ReflectionalToolFunction.java
+++ b/src/main/java/io/github/ollama4j/tools/ReflectionalToolFunction.java
@@ -8,6 +8,9 @@ import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * Specification of a {@link ToolFunction} that provides the implementation via java reflection calling.
+ */
 @Setter
 @Getter
 @AllArgsConstructor

--- a/src/main/java/io/github/ollama4j/tools/annotations/OllamaToolService.java
+++ b/src/main/java/io/github/ollama4j/tools/annotations/OllamaToolService.java
@@ -1,0 +1,13 @@
+package io.github.ollama4j.tools.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OllamaToolService {
+
+    Class<?>[] providers();
+}

--- a/src/main/java/io/github/ollama4j/tools/annotations/OllamaToolService.java
+++ b/src/main/java/io/github/ollama4j/tools/annotations/OllamaToolService.java
@@ -1,13 +1,23 @@
 package io.github.ollama4j.tools.annotations;
 
+import io.github.ollama4j.OllamaAPI;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotates a class that calls {@link io.github.ollama4j.OllamaAPI} such that the Method
+ * {@link OllamaAPI#registerAnnotatedTools()} can be used to auto-register all provided classes (resp. all
+ * contained Methods of the provider classes annotated with {@link ToolSpec}).
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface OllamaToolService {
 
+    /**
+     * @return Classes with no-arg constructor that will be used for tool-registration.
+     */
     Class<?>[] providers();
 }

--- a/src/main/java/io/github/ollama4j/tools/annotations/ToolProperty.java
+++ b/src/main/java/io/github/ollama4j/tools/annotations/ToolProperty.java
@@ -5,13 +5,28 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotates a Method Parameter in a {@link ToolSpec} annotated Method. A parameter annotated with this annotation will
+ * be part of the tool description that is sent to the llm for tool-calling.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 public @interface ToolProperty {
 
+    /**
+     * @return name of the parameter that is used for the tool description. Has to be set as depending on the caller,
+     * method name backtracking is not possible with reflection.
+     */
     String name();
 
+    /**
+     * @return a detailed description of the parameter. This is used by the llm called to specify, which property has
+     * to be set by the llm and how this should be filled.
+     */
     String desc();
 
+    /**
+     * @return tells the llm that it has to set a value for this property.
+     */
     boolean required() default true;
 }

--- a/src/main/java/io/github/ollama4j/tools/annotations/ToolProperty.java
+++ b/src/main/java/io/github/ollama4j/tools/annotations/ToolProperty.java
@@ -1,0 +1,17 @@
+package io.github.ollama4j.tools.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface ToolProperty {
+
+    String name();
+
+    String desc();
+
+    boolean required() default true;
+}

--- a/src/main/java/io/github/ollama4j/tools/annotations/ToolSpec.java
+++ b/src/main/java/io/github/ollama4j/tools/annotations/ToolSpec.java
@@ -1,0 +1,15 @@
+package io.github.ollama4j.tools.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ToolSpec {
+
+    String name() default "";
+
+    String desc();
+}

--- a/src/main/java/io/github/ollama4j/tools/annotations/ToolSpec.java
+++ b/src/main/java/io/github/ollama4j/tools/annotations/ToolSpec.java
@@ -1,15 +1,28 @@
 package io.github.ollama4j.tools.annotations;
 
+import io.github.ollama4j.OllamaAPI;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotates Methods of classes that should be registered as tools by {@link OllamaAPI#registerAnnotatedTools()}
+ * automatically.
+ */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ToolSpec {
 
+    /**
+     * @return tool-name that the method should be used as. Defaults to the methods name.
+     */
     String name() default "";
 
+    /**
+     * @return a detailed description of the method that can be interpreted by the llm, whether it should call the tool
+     * or not.
+     */
     String desc();
 }

--- a/src/test/java/io/github/ollama4j/integrationtests/TestRealAPIs.java
+++ b/src/test/java/io/github/ollama4j/integrationtests/TestRealAPIs.java
@@ -317,7 +317,7 @@ class TestRealAPIs {
             List<OllamaChatToolCalls> toolCalls = chatResult.getChatHistory().get(1).getToolCalls();
             assertEquals(1, toolCalls.size());
             OllamaToolCallsFunction function = toolCalls.get(0).getFunction();
-            assertEquals("computeMkeConstant", function.getName());
+            assertEquals("computeImportantConstant", function.getName());
             assertEquals(1, function.getArguments().size());
             Object noOfDigits = function.getArguments().get("noOfDigits");
             assertNotNull(noOfDigits);

--- a/src/test/java/io/github/ollama4j/samples/AnnotatedTool.java
+++ b/src/test/java/io/github/ollama4j/samples/AnnotatedTool.java
@@ -1,0 +1,21 @@
+package io.github.ollama4j.samples;
+
+import io.github.ollama4j.tools.annotations.ToolProperty;
+import io.github.ollama4j.tools.annotations.ToolSpec;
+
+import java.math.BigDecimal;
+
+public class AnnotatedTool {
+
+    @ToolSpec(desc = "Computes the most important constant all around the globe!")
+    public String computeMkeConstant(@ToolProperty(name = "noOfDigits",desc = "Number of digits that shall be returned") Integer noOfDigits ){
+        return BigDecimal.valueOf((long)(Math.random()*1000000L),noOfDigits).toString();
+    }
+
+    @ToolSpec(desc = "Says hello to a friend!")
+    public String sayHello(@ToolProperty(name = "name",desc = "Name of the friend") String name, Integer someRandomProperty, @ToolProperty(name="amountOfHearts",desc = "amount of heart emojis that should be used",  required = false) Integer amountOfHearts) {
+        String hearts = amountOfHearts!=null ? "♡".repeat(amountOfHearts) : "";
+        return "Hello " + name +" ("+someRandomProperty+") " + hearts;
+    }
+
+}

--- a/src/test/java/io/github/ollama4j/samples/AnnotatedTool.java
+++ b/src/test/java/io/github/ollama4j/samples/AnnotatedTool.java
@@ -8,7 +8,7 @@ import java.math.BigDecimal;
 public class AnnotatedTool {
 
     @ToolSpec(desc = "Computes the most important constant all around the globe!")
-    public String computeMkeConstant(@ToolProperty(name = "noOfDigits",desc = "Number of digits that shall be returned") Integer noOfDigits ){
+    public String computeImportantConstant(@ToolProperty(name = "noOfDigits",desc = "Number of digits that shall be returned") Integer noOfDigits ){
         return BigDecimal.valueOf((long)(Math.random()*1000000L),noOfDigits).toString();
     }
 


### PR DESCRIPTION
Adds declarative / annotation based tool registration capabilities to OllamaAPI class.

This allows ollama4j users to specify Service Classes where tools can be provided corresponding to their business functionality. Furthermore, I think this leads to the separation of tool-specification, tool registration and chat endpoint calling.

At the moment, the implementation is done quite coarse grained using brute force reflection calls, but for a first impression / poc, it should be sufficient.

Further improvements could be:
* Auto-Type detection of parameters
* Auto Registration of provided tools
* Precision of tool choice of a provider.

A sample of the implementation can be found in the integration tests as well as the documentation.

@amithkoujalgi Please see, if you are happy with this approach as this should solve one of your "improvement" ideas of the tool calling section.

Cheers and I hope you all get a good start to the new year!