### PR TITLE
Add ability to stream tokens in chat

### DIFF
--- a/src/main/java/io/github/ollama4j/models/chat/OllamaChatStreamObserver.java
+++ b/src/main/java/io/github/ollama4j/models/chat/OllamaChatStreamObserver.java
@@ -1,31 +1,19 @@
 package io.github.ollama4j.models.chat;
 
 import io.github.ollama4j.models.generate.OllamaStreamHandler;
+import io.github.ollama4j.models.generate.OllamaTokenHandler;
+import lombok.RequiredArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public class OllamaChatStreamObserver {
-
-    private OllamaStreamHandler streamHandler;
-
-    private List<OllamaChatResponseModel> responseParts = new ArrayList<>();
-
+@RequiredArgsConstructor
+public class OllamaChatStreamObserver implements OllamaTokenHandler {
+    private final OllamaStreamHandler streamHandler;
     private String message = "";
 
-    public OllamaChatStreamObserver(OllamaStreamHandler streamHandler) {
-        this.streamHandler = streamHandler;
+    @Override
+    public void accept(OllamaChatResponseModel token) {
+        if (streamHandler != null) {
+            message += token.getMessage().getContent();
+            streamHandler.accept(message);
+        }
     }
-
-    public void notify(OllamaChatResponseModel currentResponsePart) {
-        responseParts.add(currentResponsePart);
-        handleCurrentResponsePart(currentResponsePart);
-    }
-
-    protected void handleCurrentResponsePart(OllamaChatResponseModel currentResponsePart) {
-        message = message + currentResponsePart.getMessage().getContent();
-        streamHandler.accept(message);
-    }
-
-
 }

--- a/src/main/java/io/github/ollama4j/models/generate/OllamaTokenHandler.java
+++ b/src/main/java/io/github/ollama4j/models/generate/OllamaTokenHandler.java
@@ -1,0 +1,8 @@
+package io.github.ollama4j.models.generate;
+
+import io.github.ollama4j.models.chat.OllamaChatResponseModel;
+
+import java.util.function.Consumer;
+
+public interface OllamaTokenHandler extends Consumer<OllamaChatResponseModel> {
+}

--- a/src/test/java/io/github/ollama4j/integrationtests/TestRealAPIs.java
+++ b/src/test/java/io/github/ollama4j/integrationtests/TestRealAPIs.java
@@ -321,7 +321,7 @@ class TestRealAPIs {
             assertEquals(1, function.getArguments().size());
             Object noOfDigits = function.getArguments().get("noOfDigits");
             assertNotNull(noOfDigits);
-            assertEquals("5",noOfDigits);
+            assertEquals("5", noOfDigits.toString());
             assertTrue(chatResult.getChatHistory().size()>2);
             List<OllamaChatToolCalls> finalToolCalls = chatResult.getResponseModel().getMessage().getToolCalls();
             assertNull(finalToolCalls);


### PR DESCRIPTION
The current API provides an interface to get a chat response in a streaming manner, but instead of individual tokens, you only get the token concatenated to the previous responses.

In many cases this is not desirable. It is possible to "deconcatenate" is, but it seems very wasteful to spend CPU cycles and memory to concatenate a string, and afterwards split it again.

This PR adds the `ollamaApi.chatStreaming`, which takes an `OllamaTokenObserver`. This allows access to each individual token as well as metadata as it's being streamed. The original `ollamaApi.chat` was modified to convert an `OllamaStreamObserver` into an `OllamaTokenObserver`.

Care was taken to make sure that the API stays backward compatible. The method `chatStreaming` was introduced instead of adding an overwrite, because otherwise calling the `chat` method with a lambda would result in a compile errors as it would not be able to differentiate between `chat(OllamaStreamObserver)` and `chat(OllamaTokenObserver)`. 

Finally, it also fixes a random test failure in one of the tests.