### PR TITLE
docs: add "Using with llmman" section and docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ _Find more details on the **[website](https://ollama4j.github.io/ollama4j/)**._
         - [Using Maven Central](#using-maven-central)
         - [Using GitHub's Maven Package Repository](#using-githubs-maven-package-repository)
     - [For Gradle](#for-gradle)
+    - [Using with llmman](#using-with-llmman)
 - [API Spec](#api-spec)
 - [Examples](#examples)
 - [Development](#development)
@@ -226,6 +227,15 @@ dependencies {
 [lib]: https://central.sonatype.com/artifact/io.github.ollama4j/ollama4j
 
 [lib-shield]: https://img.shields.io/badge/ollama4j-get_latest_version-blue.svg?style=just-the-message&labelColor=gray
+
+### Using with llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and
+Anthropic-compatible ones) on port `17434`. Ollama4j works with it unchanged; just point the client at its host:
+
+```java
+Ollama ollama = new Ollama("http://localhost:17434");
+```
 
 ### API Spec
 

--- a/docs/docs/apis-extras/llmman.md
+++ b/docs/docs/apis-extras/llmman.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 8
+---
+
+# Using with llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and
+Anthropic-compatible ones) on port `17434`. Models are pulled as OCI artifacts or straight from Hugging Face
+(`hf.co/org/model`) and served by `llama.cpp`, `vllm` or `mlx-lm`.
+
+Because llmman speaks the same API, Ollama4j works with it unchanged. The only difference from Ollama is the port.
+
+### Start llmman
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+llmman pull gemma4
+llmman serve
+```
+
+The server listens on `http://localhost:17434` by default (override with the `LLMMAN_HOST` environment variable).
+
+### Point Ollama4j at it
+
+```java
+import io.github.ollama4j.Ollama;
+
+public class Main {
+
+    public static void main(String[] args) {
+        String host = "http://localhost:17434/";
+
+        Ollama ollama = new Ollama(host);
+
+        ollama.ping();
+    }
+}
+```


### PR DESCRIPTION
## Description

Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- `README.md`: new `### Using with llmman` subsection under Usage (plus a ToC entry) showing `new Ollama("http://localhost:17434")`.
- `docs/docs/apis-extras/llmman.md`: new "Extras" page (`sidebar_position: 8`) modelled on `ping.md` / `timeouts.md`: install/start commands and a client snippet.
- No library code changed: `Ollama` takes the host explicitly, so there is nothing to extend.

## Type of change

- [x] docs: Documentation update

## How has this been tested?

**Testing:** `cd docs && npm ci && npx docusaurus build` succeeds and generates `build/apis-extras/llmman/index.html`.

## Checklist

- [ ] I ran `pre-commit run -a` locally (hook env fails to install on this machine; whitespace/EOL checked manually)
- [ ] `make build` succeeds locally (not run; docs-only change)
- [x] Unit/integration tests added or updated as needed (none needed)
- [x] Docs updated (README/docs site) if user-facing changes
- [x] PR title follows Conventional Commits

## Breaking changes

None.

## Related issues

None.

> AI-assisted, reviewed before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for connecting Ollama4j to llmman on port `17434`.
  - Documented installation, model management, serving, host configuration, and a Java connection example.
  - Noted that llmman does not provide the `/api/embed` endpoint.
  - Added the new llmman documentation page to the README table of contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->